### PR TITLE
Add composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+  "name": "jbrinley/WP-Router",
+  "description": "Routes paths to callback functions in WordPress",
+  "keywords": ["wordpress", "plugin"],
+  "homepage": "https://github.com/jbrinley/WP-Router",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Jonathan Brinley",
+      "homepage": "http://xplus3.net/"
+    }
+  ],
+  "type": "wordpress-plugin",
+  "support": {
+    "issues": "https://github.com/jbrinley/WP-Router/issues",
+    "wiki": "https://github.com/jbrinley/WP-Router/wiki",
+    "source": "https://github.com/jbrinley/WP-Router"
+  },
+  "require": {
+    "composer/installers": "~1.0"
+  }
+}


### PR DESCRIPTION
This pull request adds a composer.json file, which makes installation via Composer possible.

While there is a mirror of WP-Router at the wpackagist repository, it's based on the latest available version from WordPress.org, and is missing the latest commits available on Github.

Installing via Composer will allow developers to install development versions of the plugin, lock to specific commits hashes, etc., before changes are propagated to WordPress.org (and thus, wpackagist).

Here's an example of how this would be done in a project's composer.json file:

``` json
...
  "repositories": [
    {
      "type": "vcs",
      "url" : "https://github.com/jbrinley/WP-Router"
    }
  ],
  "require": {
    "jbrinley/WP-Router": "dev-master"
  },
...
```

I used two-space-tab JSON, rather than a tab character. This is normal for JSON, but a bit unusual for WordPress (many plugins with composer.json files use the tab character in JSON). If you'd like to use a tab character, I'm happy to update the PR.
