### PR TITLE
Make identify_route a public function

### DIFF
--- a/WP_Router.class.php
+++ b/WP_Router.class.php
@@ -216,7 +216,7 @@ class WP_Router extends WP_Router_Utility {
 	 * @param WP|WP_Query $query
 	 * @return string|NULL
 	 */
-	protected function identify_route( $query ) {
+	public function identify_route( $query ) {
 		if ( !isset($query->query_vars[self::QUERY_VAR]) ) {
 			return NULL;
 		}


### PR DESCRIPTION
Making `identify_route` a public function makes it possible to check which route you're currently on, making template re-use a bit easier in instances where there are only minor changes between routes.

For instance...

``` php
// my-signup-template.php

Signup form fields

<?php global $wp_query; if ( \WP_Router::get_instance()->identify_route( $wp_query ) === 'registerAdmin' ) : ?>
Special form fields for admins
<?php endif; ?>

Submit button
```

I can't think of any major security issues, but I might be missing something obvious!
