### PR TITLE
depreciated use of get_class() patch

### DIFF
--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -128,11 +128,12 @@ class WP_Router_Page extends WP_Router_Utility {
 	 * @param object $post
 	 * @return void
 	 */
-	public function set_post_contents( $post ) {
-		global $pages;
-		$pages = array($this->contents);
-		// TODO: add a facility for multi-page documents?
-	}
+    public function set_post_contents( $post ) {
+        if ( $post->post_type == WP_Router_Page::POST_TYPE ) {
+            global $pages;
+            $pages = array( $this->contents );
+        }
+    }
 
 	/**
 	 * Set the title for the placeholder page

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -130,9 +130,9 @@ class WP_Router_Page extends WP_Router_Utility {
      * @return void
      */
     public function set_post_contents( $post ) {
-        if ( $post->post_type == WP_Router_Page::POST_TYPE ) {
+        if ( WP_Router_Page::POST_TYPE == $post->post_type ) {
             global $pages;
-            $pages = array( $this->contents );
+            $pages = [ $this->contents ];
         }
     }
 

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -122,20 +122,20 @@ class WP_Router_Page extends WP_Router_Utility {
 		}
 	}
 
-    /**
-     * Override the global $pages array to yield our content
-     *
-     * @param WP_Post $post WordPress Post object.
-     *
-     * @return void
-     */
-    public function set_post_contents( $post ) {
-        if ( WP_Router_Page::POST_TYPE !== $post->post_type ) {
-            return;
-        }
-        global $pages;
-        $pages = [ $this->contents ];
-    }
+	/**
+	 * Override the global $pages array to yield our content
+	 *
+	 * @param WP_Post $post WordPress Post object.
+	 *
+	 * @return void
+	 */
+	public function set_post_contents( $post ) {
+		if ( WP_Router_Page::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		global $pages;
+		$pages = [ $this->contents ];
+	}
 
 	/**
 	 * Set the title for the placeholder page

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -125,15 +125,16 @@ class WP_Router_Page extends WP_Router_Utility {
     /**
      * Override the global $pages array to yield our content
      *
-     * @param object $post
+     * @param WP_Post $post WordPress Post object.
      *
      * @return void
      */
     public function set_post_contents( $post ) {
-        if ( WP_Router_Page::POST_TYPE == $post->post_type ) {
-            global $pages;
-            $pages = [ $this->contents ];
+        if ( WP_Router_Page::POST_TYPE !== $post->post_type ) {
+            return;
         }
+        global $pages;
+        $pages = [ $this->contents ];
     }
 
 	/**

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -122,12 +122,13 @@ class WP_Router_Page extends WP_Router_Utility {
 		}
 	}
 
-	/**
-	 * Override the global $pages array to yield our content
-	 *
-	 * @param object $post
-	 * @return void
-	 */
+    /**
+     * Override the global $pages array to yield our content
+     *
+     * @param object $post
+     *
+     * @return void
+     */
     public function set_post_contents( $post ) {
         if ( $post->post_type == WP_Router_Page::POST_TYPE ) {
             global $pages;

--- a/WP_Router_Sample.class.php
+++ b/WP_Router_Sample.class.php
@@ -7,7 +7,7 @@
  
 class WP_Router_Sample {
 	public static function init() {
-		add_action('wp_router_generate_routes', array(get_class(), 'generate_routes'), 10, 1);
+		add_action('wp_router_generate_routes', array(get_called_class(), 'generate_routes'), 10, 1);
 	}
 
 	public static function generate_routes( WP_Router $router ) {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "jbrinley/wp-router",
+	"name": "the-events-calendar/wp-router",
 	"description": "Provides a simple API for mapping requests to callback functions.",
 	"type": "wordpress-plugin",
 	"authors": [

--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,10 @@ Creating or changing routes should always occur in the context of the `wp_router
 
 == Changelog ==
 
+= TBD =
+
+* Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router.
+
 = 0.6 =
 
 * Make magic methods public to avoid fatal with PHP 7.3

--- a/readme.txt
+++ b/readme.txt
@@ -142,7 +142,7 @@ Creating or changing routes should always occur in the context of the `wp_router
 
 == Changelog ==
 
-= TBD =
+= 0.7 =
 
 * Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router. [CE-192]
 

--- a/readme.txt
+++ b/readme.txt
@@ -144,7 +144,7 @@ Creating or changing routes should always occur in the context of the `wp_router
 
 = TBD =
 
-* Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router.
+* Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router. [CE-192]
 
 = 0.6 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -142,7 +142,7 @@ Creating or changing routes should always occur in the context of the `wp_router
 
 == Changelog ==
 
-= 0.7 =
+= 0.6.1 =
 
 * Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router. [CE-192]
 

--- a/wp-router.php
+++ b/wp-router.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/jbrinley/WP-Router
 Description: Provides a simple API for mapping requests to callback functions.
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 0.6
+Version: 0.7
 */
 /*
 Copyright (c) 2012 Flightless, Inc. http://flightless.us/

--- a/wp-router.php
+++ b/wp-router.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/jbrinley/WP-Router
 Description: Provides a simple API for mapping requests to callback functions.
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 0.7
+Version: 0.6.1
 */
 /*
 Copyright (c) 2012 Flightless, Inc. http://flightless.us/


### PR DESCRIPTION
Removed the depricated use of the function get_class() without input.
Introduced the new function get_called_class() which returns the name of the class a static method was called in.