### PR TITLE
Deprecated use of get_class() - patch

### DIFF
--- a/WP_Router_Sample.class.php
+++ b/WP_Router_Sample.class.php
@@ -16,7 +16,7 @@ class WP_Router_Sample {
 			'query_vars' => array(
 				'sample_argument' => 1,
 			),
-			'page_callback' => array(get_class(), 'sample_callback'),
+			'page_callback' => array(get_called_class(), 'sample_callback'),
 			'page_arguments' => array('sample_argument'),
 			'access_callback' => TRUE,
 			'title' => 'WP Router Sample Page',

--- a/WP_Router_Sample.class.php
+++ b/WP_Router_Sample.class.php
@@ -7,7 +7,7 @@
  
 class WP_Router_Sample {
 	public static function init() {
-		add_action('wp_router_generate_routes', array(get_called_class(), 'generate_routes'), 10, 1); //avoid depricated get_class() without input
+		add_action('wp_router_generate_routes', array(get_called_class(), 'generate_routes'), 10, 1);
 	}
 
 	public static function generate_routes( WP_Router $router ) {

--- a/WP_Router_Sample.class.php
+++ b/WP_Router_Sample.class.php
@@ -7,7 +7,7 @@
  
 class WP_Router_Sample {
 	public static function init() {
-		add_action('wp_router_generate_routes', array(get_class(), 'generate_routes'), 10, 1);
+		add_action('wp_router_generate_routes', array(get_called_class(), 'generate_routes'), 10, 1); //avoid depricated get_class() without input
 	}
 
 	public static function generate_routes( WP_Router $router ) {


### PR DESCRIPTION
Removed the depricated use of the function get_class() without input.
Introduced the new function get_called_class() which returns the name of the class a static method was called in.